### PR TITLE
Link TabLineFill to StatusLineNC

### DIFF
--- a/colors/spacegray.vim
+++ b/colors/spacegray.vim
@@ -117,7 +117,6 @@ else
 endif
 
 hi TabLine         ctermbg=232  ctermfg=249    guibg=#141617  guifg=#B3B8C4  cterm=NONE      gui=NONE
-hi TabLineFill     ctermbg=235  ctermfg=239    guibg=#303537  guifg=#303537  cterm=NONE      gui=NONE
 hi TabLineSel      ctermbg=145  ctermfg=0      guibg=#7D8FA3  guifg=#111314  cterm=NONE      gui=NONE
 
 hi Directory       ctermbg=NONE ctermfg=24     guibg=NONE     guifg=#5FAFAF  cterm=NONE      gui=NONE
@@ -159,7 +158,8 @@ hi link SpecialChar         Special
 hi link SpecialComment      Special
 hi link Tag                 Special
 
-hi link VertSplit           StatusLineNC
+hi! link VertSplit          StatusLineNC
+hi! link TabLineFill        StatusLineNC
 
 " HTML
 hi link htmlEndTag          htmlTagName


### PR DESCRIPTION
This PR links TabLineFill to StatusLineNC. Also it seems like we need to use `hi!` instead of `hi` to link the default groups. 
before:
<img width="877" alt="screen shot 2018-12-25 at 11 45 19 pm" src="https://user-images.githubusercontent.com/144778/50426477-27ad4580-089f-11e9-8400-d891b42dc200.png">

after:
<img width="864" alt="screen shot 2018-12-25 at 11 42 28 pm" src="https://user-images.githubusercontent.com/144778/50426466-077d8680-089f-11e9-98ff-df4097de1abd.png">
